### PR TITLE
Fix php notice. Closes #86

### DIFF
--- a/classes/class-woothemes-sensei-certificate-templates.php
+++ b/classes/class-woothemes-sensei-certificate-templates.php
@@ -406,7 +406,7 @@ class WooThemes_Sensei_Certificate_Templates {
 		$show_border = 0;
 
 		// Get Student Data
-		get_currentuserinfo();
+		wp_get_current_user();
 		$fname = $current_user->first_name;
 		$lname = $current_user->last_name;
 		$student_name = $current_user->display_name;


### PR DESCRIPTION
> Notice: get_currentuserinfo is deprecated since version 4.5! Use wp_get_current_user() instead. in /srv/www/sensei-master/htdocs/wp-includes/functions.php on line 3662
FPDF error: Some data has already been output, can't send PDF file